### PR TITLE
Fixed improper mailto link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 - 📫 How to reach me:
   
-  :email: : mailto:srinath141099@gmail.com               
+  :email: : [srinath141099@gmail.com](mailto:srinath141099@gmail.com)               
   :briefcase: : https://www.linkedin.com/in/srinath-r/
 
 


### PR DESCRIPTION
The README was rendering as mailto:srinath141099@gmail.com,
while, it should have rendered as srinath141099@gmail.com. I've fixed the link by adding the correct mailto format.